### PR TITLE
Allow json top level strings to be parsed by JRuby's JSON

### DIFF
--- a/lib/puppet/functions/hiera_vault.rb
+++ b/lib/puppet/functions/hiera_vault.rb
@@ -120,7 +120,7 @@ Puppet::Functions.create_function(:hiera_vault) do
 
         if options['default_field_parse'] == 'json'
           begin
-            new_answer = JSON.parse(new_answer)
+            new_answer = JSON.parse(new_answer, :quirks_mode => true)
           rescue JSON::ParserError => e
             context.explain { "[hiera-vault] Could not parse string as json: #{e}" }
           end


### PR DESCRIPTION
Allow vault entries with json_value set to quoted strings to be parsed.

Currently, if an entry in vault is set to `json_value: "abc\ndef"`, the JRuby version of JSON will fail to parse this value, causing the hiera_vault function to return the string `'"abc\ndef"'` (including quotes and newline char).

For the standard ruby implementation of JSON, nothing changes, it by default allowed to parse top level strings.